### PR TITLE
Handle 'OK *' messages from imap server

### DIFF
--- a/imapexecute/__main__.py
+++ b/imapexecute/__main__.py
@@ -72,6 +72,8 @@ def loop():
             connection_name = sock.name
             connection = connections[connection_name]
             uid, message = connection.get_event()
+            if not uid:
+                continue
             if message == 'EXISTS':
                 connection.done()
                 print('Fetching message {} for account [{}]'.format(uid, connection_name))

--- a/imapexecute/idle.py
+++ b/imapexecute/idle.py
@@ -16,9 +16,15 @@ def get_event(connection):
     resp = connection.readline().decode()
     print(resp)
     part = resp[2:].split('(', maxsplit=1)
-    uid, message = part[0].strip().split(' ')
-    return uid, message
+    part = part[0].strip()
 
+    parts = part.split(' ')
+    # for any part that are not in the format '<uid> <message>',
+    # just return the part
+    if len(parts) > 2:
+        return None, part
+    uid, message = parts
+    return uid, message
 
 def done(connection):
     connection.send("DONE\r\n".encode())


### PR DESCRIPTION
My mail provider's imap server responds periodically with a "OK Still
here" message. As a result, a ValueError is raised when get_event tries
to unpack the message using space delim. This returns if the part does
not fit the format '<uid> <message>', and just prints the part to stdout
instead of trying to take any action on it.